### PR TITLE
feat: 섹션 6에 연혁 추가 + 약간의 반응형 디자인 + 트랜지션 자연스럽게 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 // 라우팅을 담당하는 App입니다.
 // 페이지를 제작할 때 Navigation의 높이만큼 padding 또는 margin을 추가해야 페이지의 내용이 내비바 아래에 보여지게 됩니다.
 // padding 같은 추가적인 작업이 없다면 내용이 내비바보다 더 높은 위치에서부터 표시되어 일부 내용이 보이지 않습니다.
-// 내비바의 높이는 60px입니다.
+// 내비바의 높이는 80px입니다.
 
 import { Routes, Route, useLocation } from 'react-router-dom';
 
@@ -22,6 +22,7 @@ import NewArticleEditor from './pages/NewArticleEditor';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import MyPage from './pages/MyPage';
+import Section6 from './pages/Section6';
 
 export default function App() {
   // location.key을 통해 화면 전환 시 컴포넌트 충돌/중복 방지 용으로 사용됩니다.
@@ -43,6 +44,7 @@ export default function App() {
           <Route path="/signup" element={<SignUp />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="*" element={<NotFound />} />
+          <Route path="test" element={<Section6 />} />
 
           {/* 대시보드 페이지 */}
           <Route element={<DashboardLayout location={location} />}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,6 @@ export default function App() {
           <Route path="/signup" element={<SignUp />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="*" element={<NotFound />} />
-          <Route path="test" element={<Section6 />} />
 
           {/* 대시보드 페이지 */}
           <Route element={<DashboardLayout location={location} />}>

--- a/src/assets/graph.svg
+++ b/src/assets/graph.svg
@@ -1,0 +1,19 @@
+<svg width="1920" height="950" viewBox="0 0 1920 950" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+<mask id="mask0_293_812" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="1920" height="950">
+<rect width="1920" height="950" fill="url(#paint0_linear_293_812)"/>
+</mask>
+<g mask="url(#mask0_293_812)">
+<path d="M248.5 812.501C164.5 819.911 47.8333 898.504 0 936.875L-62 1007H1981V100C1952.33 120.067 1889.5 161.393 1867.5 166.156C1840 172.11 1783.5 135.724 1727 131.755C1670.5 127.786 1589.5 194.603 1444 344.116C1298.5 493.629 1308.5 661.665 1185 735.76C1061.5 809.855 986 758.914 873.5 752.96C761 747.006 535 854.841 429 854.841C323 854.841 353.5 803.239 248.5 812.501Z" fill="url(#paint1_linear_293_812)" stroke="#1A2E4B" stroke-width="5"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_293_812" x1="-72.5" y1="1003.98" x2="2052.12" y2="677.339" gradientUnits="userSpaceOnUse">
+<stop stop-color="#000915" stop-opacity="0"/>
+<stop offset="0.571341" stop-color="#00040B"/>
+<stop offset="1" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint1_linear_293_812" x1="959.5" y1="442.689" x2="959.5" y2="1007" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00132D"/>
+<stop offset="1"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/components/display/HistoryPreview.jsx
+++ b/src/components/display/HistoryPreview.jsx
@@ -1,0 +1,299 @@
+import { createRef, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { Text } from '../typograph/Text';
+
+import useHistory from '../../stores/dashboard/useHistory';
+import { API } from '../../utils/api';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+
+import '../../transitions/fade-slide.css';
+
+const PreviewWrapper = styled.div`
+  width: 600px;
+  height: 300px;
+  display: flex;
+  gap: 80px;
+`;
+
+const YearListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const HistoryListWrapper = styled.div``;
+
+const HistoryElementWrapper = styled.div`
+  padding: 15px 20px;
+  background-color: #ffffff10;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+`;
+
+const YearWrapper = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 34px;
+  background-color: transparent;
+  outline: none;
+  border: none;
+  cursor: pointer;
+
+  &:not(.active) > span {
+    color: #303146;
+  }
+
+  &:not(.active) > div {
+    background-color: #303146;
+  }
+
+  &:last-child > div:after {
+    background: linear-gradient(
+      0deg,
+      rgba(48, 49, 70, 0) 0%,
+      rgba(48, 49, 70, 1) 100%
+    );
+  }
+`;
+
+const Year = styled.span`
+  transition: color 0.2s ease-in-out;
+  width: 63px;
+  font-weight: 800;
+  font-size: 22px;
+  text-align: left;
+  color: white;
+`;
+
+const Dot = styled.div`
+  position: relative;
+  transition: background-color 0.2s ease-in-out;
+  width: 14px;
+  height: 14px;
+  border-radius: 100%;
+  background-color: white;
+
+  &:after {
+    transform: background 0.2s ease-in-out;
+    content: '';
+    position: absolute;
+    z-index: -10;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    height: 60px;
+    background: #303146;
+  }
+`;
+
+const HistoryElement = ({ history }) => {
+  return (
+    <HistoryElementWrapper>
+      <Text size="s" color="#ffffff88">
+        {history.year}.{history.month}
+      </Text>
+      <Text size="m" color="white">
+        {history.description}
+      </Text>
+    </HistoryElementWrapper>
+  );
+};
+
+export const HistoryPreview = () => {
+  const nodeRef = createRef(null);
+  const [display_year, setDisplayYear] = useState();
+  const { saveHistory, histories } = useHistory(); // 불러온 데이터를 저장할 상태
+
+  useEffect(() => {
+    // 만약 이전에 받은 API 데이터가 없다면 API 요청 후 데이터를 store에 저장
+    if (Object.keys(histories).length === 0) {
+      API.GET('/histories')
+        .then((api_res) => {
+          const return_value = saveHistory(api_res); // API 데이터를 Zustand 상태에 반영
+          setDisplayYear(Object.keys(return_value).reverse().at(0));
+          console.log(api_res);
+        })
+        .catch((err) => {
+          // 오류 발생 시 안내
+          console.warn('History API 통신 실패. 기본 데이터를 사용합니다.', err);
+          const return_value = saveHistory([
+            {
+              id: 0,
+              year: 1997,
+              month: 11,
+              description: '동아리 창립',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 1,
+              year: 2006,
+              month: 4,
+              description: '정보보호대학동아리엽학 KUCIS 소속',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 2,
+              year: 2008,
+              month: 8,
+              description: '한국정보보호진흥원 S/W 보안취약점 찾기 대회 우수상',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 3,
+              year: 2013,
+              month: 4,
+              description: '삼성소프트웨어프렌드쉽',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 4,
+              year: 2016,
+              month: 2,
+              description: '대경강원권 연합창업경진대회 최우수상',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 5,
+              year: 2016,
+              month: 4,
+              description: 'Naver D2 Campus 파트너 선정',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 6,
+              year: 2016,
+              month: 4,
+              description: '정보보호대학동아리연합 KUCIS 소속',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 7,
+              year: 2016,
+              month: 7,
+              description: 'KERPERENCE S/S 주최',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 8,
+              year: 2016,
+              month: 12,
+              description: 'KERPERENCE W/W 주최',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 9,
+              year: 2017,
+              month: 2,
+              description: 'KNU 창업 비즈니스 플랜 경진대회 대상',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 10,
+              year: 2017,
+              month: 4,
+              description: '정보보호대학 동아리 연합 KUCIS 소속',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 11,
+              year: 2018,
+              month: 4,
+              description: 'Naver D2 Campus 파트너 선정',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 12,
+              year: 2021,
+              month: 9,
+              description: '제2회 KOSPO 웹서비스 정보보안 경진대회 최우수상',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 13,
+              year: 2023,
+              month: 4,
+              description: 'HSpace 파트너십 체결',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 14,
+              year: 2024,
+              month: 4,
+              description: '전국사이버보안연합 CCA 소속',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+            {
+              id: 15,
+              year: 2024,
+              month: 5,
+              description: '정보보호대학동아리연합 KUCIS 소속',
+              created_at: '2024-09-26T23:48:50.068140',
+              updated_at: '2024-09-26T23:48:50.068140',
+            },
+          ]);
+          setDisplayYear(Object.keys(return_value).reverse().at(0));
+        })
+        .finally(() => {
+          console.log('History API 통신 종료');
+        });
+    } else {
+      console.info('이미 API 데이터가 있으므로 API 응답을 요청하지 않습니다.');
+    }
+  }, [histories, saveHistory]);
+
+  const display_key = Object.keys(histories).reverse().slice(0, 4);
+
+  return (
+    <PreviewWrapper>
+      <YearListWrapper>
+        {display_key.map((year, i) => (
+          <YearWrapper
+            key={i}
+            className={display_year == year ? 'active' : ''}
+            onClick={() => setDisplayYear(parseInt(year))}
+          >
+            <Year>{year}</Year>
+            <Dot />
+          </YearWrapper>
+        ))}
+      </YearListWrapper>
+      <TransitionGroup>
+        <CSSTransition
+          nodeRef={nodeRef}
+          key={display_year}
+          timeout={500}
+          classNames="fade-slide"
+          style={{ position: 'absolute' }}
+        >
+          <HistoryListWrapper ref={nodeRef}>
+            {histories[
+              display_year ?? Object.keys(histories).reverse().at(0)
+            ]?.map((history, i) => (
+              <HistoryElement key={i} history={history} />
+            ))}
+          </HistoryListWrapper>
+        </CSSTransition>
+      </TransitionGroup>
+    </PreviewWrapper>
+  );
+};

--- a/src/components/layouts/DashboardLayout.jsx
+++ b/src/components/layouts/DashboardLayout.jsx
@@ -76,6 +76,7 @@ export const DashboardLayout = ({ location }) => {
           key={location.key}
           timeout={{ enter: 500, exit: 300 }}
           classNames="fade-slide"
+          style={{ width: '100%', position: 'absolute' }}
         >
           <div ref={nodeRef} style={{ width: '100%' }}>
             {/* 전환 후 표시될 컴포넌트 */}

--- a/src/components/layouts/MainLayout.jsx
+++ b/src/components/layouts/MainLayout.jsx
@@ -1,10 +1,10 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import styled from 'styled-components';
 import { Navigation } from '../navigation/Navigation';
 
 export const Main = styled.main`
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   margin: 0px auto;
 `;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -2,12 +2,11 @@
 
 import { useState } from 'react';
 import styled from 'styled-components';
-import { keyframes } from 'styled-components';
 
 import { Span } from '../components/typograph/Text';
 
-import Square from '../assets/kert_logos/Square.svg?react';
-import NotFoundIcon from '../assets/404.svg?react';
+import Square from '../assets/kert_logos/Square.svg';
+import NotFoundIcon from '../assets/404.svg';
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/pages/Section6.jsx
+++ b/src/pages/Section6.jsx
@@ -1,233 +1,114 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import bg_img from '../assets/Section6_bg_img.png';
-import graph_img from "../assets/Section6_graph.png";
-import '../font/main_font.css';
 import styled from 'styled-components';
-import { Text } from '../components/typograph/Text';
 
-// 배경 이미지용 div를 추가해 중첩 레이어 효과를 만듦
-const BackgroundWrapper = styled.div`
-    width: 100vw;
-    height: 100vh;
-    position: relative;  
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    overflow: hidden;
+import { Span } from '../components/typograph/Text';
+import GraphSVG from '../assets/graph.svg';
+import { Link } from 'react-router-dom';
+import { HistoryPreview } from '../components/display/HistoryPreview';
+
+const SectionWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  // viewport의 높이에서 내비바 높이만큼 감소합니다.
+  min-height: calc(100vh - 80px);
+  margin-top: 80px;
+  background: linear-gradient(
+    326deg,
+    rgba(0, 9, 21, 1) 0%,
+    rgba(0, 0, 0, 1) 100%
+  );
+
+  overflow: hidden;
 `;
 
-const BackgroundImageLayer = styled.div`
-    width: 100%;
-    height: 100%;
-    background-image: url(${bg_img});
-    background-size: cover;
-    background-position: center center;
-    position: absolute;
-    z-index: 1;
+const Graph = styled(GraphSVG)`
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
 `;
 
-const GraphImageLayer = styled.div`
-    width: 100%;
-    height: 100%;
-    background-image: url(${graph_img});
-    background-size: contain;
-    background-position: right bottom;
-    background-repeat: no-repeat;
-    position: absolute;
-    z-index: 2;
-`;
-
-const ContentWrapper = styled.div`
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: flex-start; /* Align content to the left */
-    align-items: center;
-    z-index: 3;  
-    position: relative;
-    padding: 0 10%;
-`;
-
-// 왼쪽 컨테이너
-const LeftContentContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 0 50px;
-`;
-
-// 오른쪽 타임라인 컨테이너
-const RightContentContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
-    padding-left: 50px;
-    position: relative; 
-    top: 0; 
-`;
-
-/*연혁 그래프 관련 style*/
-const HistoryYear = styled.div`
-    display: flex;
-    align-items: center;
-    margin-bottom: 40px;
-    position: relative;
-`;
-
-const YearText = styled(Text)`
-    font-size: 18px;
-    font-weight: bold;
-    color: #FFFFFF;
-    margin-right: 20px;
-`;
-
-const Dot = styled.div`
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    left: 97px;
-    top: 5px;
-    background: #FFFFFF;
-    border-radius:50px;
-
-`;
-
-const PassDot=styled.div`
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    left: 97px;
-    top: 5px;
-    background: #303146;
-    border-radius:50px;
-
-`
-const EventCard = styled.div`
-    background-color: #303146;
-    color: white;
-    padding: 12px 16px;
-    border-radius: 8px;
-    margin-left: 34px;
-    font-size: 14px;
-    position: relative;
-    flex-direction: column;
-    z-index: 4;
-    transform: translateX(50px); 
-`;
-
-const EventDate = styled.div`
-    font-size: 12px;
-    color: #B0B0B0;
-    margin-bottom: 4px;
-`;
-
-//이하의 3개는 historyline 설정
-const HistoryLineWrapper = styled.div`
-    position: absolute;
-    left: 102px;
-    top: 20px;
-`;
-
-const HistoryLine = styled.div`
-    width: 4px;
-    height: 248px;  
-    background: #303146;
-`;
-
-const FadeOutLine = styled.div`
-  width: 4px;
-  height: 100px;
-  background: linear-gradient(180deg, #303146 0%, rgba(48, 49, 70, 0) 100%);
-`;
-
-// Combining HistoryLine and FadeOutLine
-const CombinedHistoryLine = () => (
-    <HistoryLineWrapper>
-        <HistoryLine />
-        <FadeOutLine />
-    </HistoryLineWrapper>
-);
-
-const Button = styled.button`
-    background: transparent;
-    border: none; 
-    color: rgba(255, 255, 255, 0.5);
-    padding: 14px 24px;
-    border-radius: 8px;
-    font-size: 10px;
-    font-weight: bold;
-    cursor: pointer;
-    transition: background 0.3s, color 0.3s;
-    position: relative;
-    z-index: 4;
-
-    &:hover {
-        background: #FFFFFF; 
-        color: #303146;  
+const Content = styled.div`
+  position: absolute;
+  width: 80%;
+  height: max-content;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 10px;
+  @media (max-width: 900px) {
+    & {
+      flex-direction: column; /* 화면이 작아지면 세로 방향 */
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      gap: 80px;
     }
-
-    &:focus {
-        outline: none;  
-    }
+  }
 `;
 
+const LeftContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
 
+  @media (max-width: 900px) {
+    & {
+      gap: 30px;
+    }
+  }
+`;
+const RightContent = styled.div``;
+
+const Title = styled(Span).attrs({
+  $weight: 'extrabold',
+})`
+  font-size: clamp(36px, 4vw, 60px);
+  word-break: keep-all;
+`;
+
+const Description = styled(Span).attrs({
+  $weight: 'light',
+})`
+  font-size: clamp(16px, 2vw, 24px);
+  word-break: keep-all;
+`;
+
+const StyledLink = styled(Link)`
+  font-weight: 300;
+  font-size: clamp(12px, 1.5vw, 20px);
+  text-decoration: none;
+  color: var(--primary-text-color);
+  opacity: 0.5;
+  width: fit-content;
+  height: fit-content;
+`;
 
 export default function Section6() {
-    const navigate = useNavigate();
-
-    function handleClick() {
-        navigate('/histories');
-    }
-
-    return (
-        <BackgroundWrapper>
-            <BackgroundImageLayer />
-            <GraphImageLayer />
-            <ContentWrapper>
-                <LeftContentContainer>
-                    <Text size="sxl" weight="extrabold">KERT는 <br/>매년 성장하고 있어요</Text>
-                    <Text size="m" weight="light" color="rgba(255, 255, 255, 0.7)">작년보다 더 뛰어난 동아리로 발전하고 있답니다.</Text>
-                    <Button onClick={handleClick}>
-                        상세 연혁 보기
-                    </Button>
-                </LeftContentContainer>
-                <RightContentContainer>
-                    <HistoryYear>
-                        <YearText>2024
-                        </YearText>
-                        <Dot active={true} />
-                        <CombinedHistoryLine/>
-                        <EventCard>
-                            <EventDate>2024.05</EventDate>
-                            정보보호대학동아리연합 KUCIS 소속
-                        </EventCard>
-                        <EventCard>
-                            <EventDate>2024.04</EventDate>
-                            전국사이버보안연합 CCA 소속
-                        </EventCard>
-
-                    </HistoryYear>
-                    
-                    <HistoryYear>
-                        <YearText>2023</YearText>
-                        <PassDot />
-                    </HistoryYear>
-                    
-                    <HistoryYear>
-                        <YearText>2021</YearText>
-                        <PassDot />
-                    </HistoryYear>
-                    
-                    <HistoryYear>
-                        <YearText>2018</YearText>
-                        <PassDot />
-                    </HistoryYear>
-                </RightContentContainer>
-            </ContentWrapper>
-        </BackgroundWrapper>
-    );
+  return (
+    <SectionWrapper>
+      {/* Scale 100% Fixed */}
+      <Graph />
+      {/* Center Fixed */}
+      <Content>
+        <LeftContent>
+          <Title>
+            KERT는
+            <br />
+            매년 성장하고 있어요
+          </Title>
+          <Description>
+            작년보다 더 뛰어난 동아리로 발전하고 있답니다.
+          </Description>
+          <StyledLink to="/history">상세 연혁 보기 →</StyledLink>
+        </LeftContent>
+        <RightContent>
+          <HistoryPreview />
+        </RightContent>
+      </Content>
+    </SectionWrapper>
+  );
 }

--- a/src/stores/dashboard/useHistory.js
+++ b/src/stores/dashboard/useHistory.js
@@ -35,6 +35,8 @@ const useHistory = create((set) => ({
   saveHistory: (api_res) => {
     const refined_histories = refineHistories(api_res);
     set({ histories: refined_histories });
+    return refined_histories;
+    // console.log(refined_histories);
   },
 }));
 

--- a/src/transitions/fade-slide.css
+++ b/src/transitions/fade-slide.css
@@ -1,33 +1,31 @@
 /* 정방향 || 들어오는 효과 */
 .fade-slide-enter {
-    opacity: 0;
-    transform: translateX(-20px);
+  opacity: 0;
+  transform: translateX(20px);
 }
-  
+
 .fade-slide-enter-active {
-    position: absolute;
-    opacity: 1;
-    transform: translateX(0px);
-    transition: all 500ms cubic-bezier(.27,.02,.26,.99) 100ms;
+  opacity: 1;
+  transform: translateX(0px);
+  transition: all 500ms cubic-bezier(0.27, 0.02, 0.26, 0.99) 100ms;
 }
 
 .fade-slide-enter-done {
-    opacity: 1;
+  opacity: 1;
 }
-
 
 /* 정방향 || 사라지는 효과 */
 .fade-slide-exit {
-    opacity: 1;
-    transform: translateX(0px);
+  opacity: 1;
+  transform: translateX(0px);
 }
 
 .fade-slide-exit-active {
-    opacity: 0;
-    transform: translateX(70px);
-    transition: all 400ms cubic-bezier(.27,.02,.26,.99);
+  opacity: 0;
+  transform: translateX(-70px);
+  transition: all 500ms cubic-bezier(0.27, 0.02, 0.26, 0.99);
 }
 
 .fade-slide-exit-done {
-    opacity: 0;
+  opacity: 0;
 }


### PR DESCRIPTION
### 메인페이지에 연혁 추가 완료

- 기본적으로 API에서 데이터를 요청하고 실패한다면 기본 데이터로 표시
- 연도를 클릭하여 표시되는 연혁 리스트를 볼 수 있음

![스크린샷 2024-09-26 235746](https://github.com/user-attachments/assets/a8cb9151-aad7-4cb9-a7ae-e80aa6f069f7)
![스크린샷 2024-09-26 235752](https://github.com/user-attachments/assets/ac0bf8e1-3d2f-4483-b689-4e327c040661)
