### PR TITLE
fix: 린트 오류 및 오타 수정

### DIFF
--- a/src/components/forms/HintedInput.jsx
+++ b/src/components/forms/HintedInput.jsx
@@ -58,3 +58,5 @@ export const HintedInput = forwardRef(
     );
   },
 );
+
+HintedInput.displayName = 'HintedInput';

--- a/src/components/forms/Input.jsx
+++ b/src/components/forms/Input.jsx
@@ -64,3 +64,5 @@ export const Input = forwardRef(({ label, value, ...props }, ref) => {
     </InputWrapper>
   );
 });
+
+Input.displayName = 'Input';

--- a/src/pages/Section6.jsx
+++ b/src/pages/Section6.jsx
@@ -25,7 +25,6 @@ const Graph = styled(GraphSVG)`
   display: block;
   width: 100%;
   height: 100%;
-}
 `;
 
 const Content = styled.div`


### PR DESCRIPTION
## Description
- `forwardRef` 로 래핑된 컴포넌트에 대해 `displayName` 를 제공하지 않아 발생하는 린트 오류 해결
- styled-components 스타일링 오타 수정