### PR TITLE
fix: API 요청 시 body, headers 객체 분리

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -16,6 +16,15 @@ async function request(endpoint, method = 'GET', data = null, headers = {}) {
     config.body = JSON.stringify(data);
   }
 
+  // 실제 배포시 주석처리 또는 제거해야합니다
+  console.log(
+    `요청 메소드: ${method}\n
+    Endpont: ${API_URL}${endpoint}\n
+    Body: ${JSON.stringify(data)}\n
+    Headers: ${JSON.stringify(headers)}\n
+    Config: ${JSON.stringify(config)}`,
+  );
+
   try {
     const response = await fetch(`${API_URL}${endpoint}`, config);
 
@@ -24,8 +33,14 @@ async function request(endpoint, method = 'GET', data = null, headers = {}) {
       throw new Error(`${response.status} ${response.statusText}`);
     }
 
+    let contentType = response.headers.get('Content-Type');
+
     // 응답 데이터를 JSON으로 반환합니다.
-    return await response.json();
+    if (contentType.includes('application/json')) {
+      return await response.json();
+    } else {
+      return await response.text();
+    }
   } catch (error) {
     console.error('요청 실패:', error);
     throw error; // 오류를 호출한 곳으로 다시 던집니다.
@@ -33,23 +48,23 @@ async function request(endpoint, method = 'GET', data = null, headers = {}) {
 }
 
 // GET 요청
-async function GET(endpoint) {
-  return await request(endpoint, 'GET');
+async function GET(endpoint, data = { body: {}, headers: {} }) {
+  return await request(endpoint, 'GET', data.body, data.headers);
 }
 
 // POST 요청
-async function POST(endpoint, data) {
-  return await request(endpoint, 'POST', data);
+async function POST(endpoint, data = { body: {}, headers: {} }) {
+  return await request(endpoint, 'POST', data.body, data.headers);
 }
 
 // PUT 요청
-async function PUT(endpoint, data) {
-  return await request(endpoint, 'PUT', data);
+async function PUT(endpoint, data = { body: {}, headers: {} }) {
+  return await request(endpoint, 'PUT', data.body, data.headers);
 }
 
 // DELETE 요청
-async function DELETE(endpoint) {
-  return await request(endpoint, 'DELETE');
+async function DELETE(endpoint, data = { body: {}, headers: {} }) {
+  return await request(endpoint, 'DELETE', data.body, data.headers);
 }
 
 export const API = {


### PR DESCRIPTION
## 기존 요청 방식
- 아래와 같은 방식은 data 전송은 되지만 headers 전송이 되지 않습니다.
- 하단 수정된 요청 방식을 참고하여 코드 수정이 필요합니다.
```javascript
// headers가 있지만 headers로 전송되지 않음
API.GET("/endpoint", {
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
API.POST("/endpoint", {
	headers: {
		Authorization: "KEY"
	},
	student_id: 2024000000
})
```

## 수정된 요청 방식
- API.*로 넘기는 데이터 객체 속에 body와 headers라는 객체를 선언해야합니다.

```javascript
// 인증만 포함된 GET 요청
API.GET("/endpoint", {
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
// 추가적인 데이터와 함께 인증이 포함된 GET
API.GET("/endpoint", {
	body: {
		student_id: 2024000000
	},
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
// 추가적인 데이터와 함께 인증이 포함된 POST
API.POST("/endpoint", {
	body: {
		student_id: 2024000000,
		student_name: "홍길동"
	},
	headers: {
		Authorization: "KEY"
	}
})
```
