### PR TITLE
hotfix: GET/DELETE에서 body 전송 금지

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -49,7 +49,8 @@ async function request(endpoint, method = 'GET', data = null, headers = {}) {
 
 // GET 요청
 async function GET(endpoint, data = { body: {}, headers: {} }) {
-  return await request(endpoint, 'GET', data.body, data.headers);
+  // GET 요청은 body를 사용하지 않습니다.
+  return await request(endpoint, 'GET', null, data.headers);
 }
 
 // POST 요청
@@ -64,7 +65,8 @@ async function PUT(endpoint, data = { body: {}, headers: {} }) {
 
 // DELETE 요청
 async function DELETE(endpoint, data = { body: {}, headers: {} }) {
-  return await request(endpoint, 'DELETE', data.body, data.headers);
+  // DELETE 요청은 body를 사용하지 않습니다.
+  return await request(endpoint, 'DELETE', null, data.headers);
 }
 
 export const API = {


### PR DESCRIPTION
## 수정사항
- #54 에서 수정했던 코드 중 GET과 DELETE에 포함된 body는 전달받아도 실제 서버엔 전송하지 않도록 수정

## 기존 요청 방식
- 아래와 같은 방식은 data 전송은 되지만 headers가 body처럼 전송됩니다.
- 맨하단 수정된 요청 방식을 참고하여 코드 수정이 필요합니다.
```javascript
// headers가 있지만 headers로 전송되지 않음
API.GET("/endpoint", {
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
API.POST("/endpoint", {
	headers: {
		Authorization: "KEY"
	},
	student_id: 2024000000
})
```

## 수정된 요청 방식
- API.*로 넘기는 데이터 객체 속에 body와 headers라는 객체를 선언해야합니다.

```javascript
// 인증만 포함된 GET 요청
API.GET("/endpoint", {
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
// body를 포함해도 실제 서버로 전송되지 않습니다.
API.GET("/endpoint", {
	body: {
		student_id: 2024000000
	},
	headers: {
		Authorization: "KEY"
	}
})
```
```javascript
// 추가적인 데이터와 함께 인증이 포함된 POST
API.POST("/endpoint", {
	body: {
		student_id: 2024000000,
		student_name: "홍길동"
	},
	headers: {
		Authorization: "KEY"
	}
})
```

### 실제 코드 작성 예시
![image](https://github.com/user-attachments/assets/e136ec43-a123-4cf5-b1a9-8de568e8bc78)

