### PR TITLE
Fix/ApplyTheme - 올바른 테마 적용 및 Null 에러 수정 외 9가지 수정사항

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import { GlobalStyle } from './styles/global';
 import { MainLayout } from './components/layouts/MainLayout';
 import './styles/font.css';
 
+import useTheme from './hooks/theme/useTheme';
+
 import { AuthProvider } from './components/navigation/AuthContext';
 import Navigator from './components/navigation/Navigation';
 
@@ -18,7 +20,7 @@ import NotFound from './pages/NotFound';
 
 import { DashboardLayout } from './components/layouts/DashboardLayout';
 import { Dashboard } from './pages/dashboard';
-import DevDocument from './pages/DevDocument';
+// import DevDocument from './pages/DevDocument';
 import Board from './pages/Board';
 import Article from './pages/Article';
 import NewArticleEditor from './pages/NewArticleEditor';
@@ -26,12 +28,14 @@ import NewArticleEditor from './pages/NewArticleEditor';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import MyPage from './pages/MyPage';
-
 import History from './pages/History';
 
 export default function App() {
   // location.key을 통해 화면 전환 시 컴포넌트 충돌/중복 방지 용으로 사용됩니다.
   const location = useLocation();
+
+  // 테마 적용
+  useTheme();
 
   return (
     <>

--- a/src/components/display/HistoryPreview.jsx
+++ b/src/components/display/HistoryPreview.jsx
@@ -206,13 +206,6 @@ export const HistoryPreview = () => {
 
       return data;
     },
-    {
-      retry: false,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchInterval: false,
-    },
   );
 
   useEffect(() => {

--- a/src/components/display/ShapeBackground.jsx
+++ b/src/components/display/ShapeBackground.jsx
@@ -30,7 +30,7 @@ const Shape = styled.div`
   border-radius: ${({ radius }) => radius || '20px'};
   background-color: ${({ color }) => color || '#213EA6'};
 
-  opacity: 0.03;
+  opacity: 0.1;
   overflow: hidden;
 
   animation: ${({ $startAngle, $direction }) => rotate($startAngle, $direction)}

--- a/src/components/display/dashboard/home/board/Admin.jsx
+++ b/src/components/display/dashboard/home/board/Admin.jsx
@@ -13,14 +13,10 @@ import { API } from '@/utils/api';
 
 export const Admin = () => {
   const navigate = useNavigate();
-  const { data, isLoading } = useQuery(
-    'admin',
-    async () => {
-      const res = await API.GET('/admin');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data, isLoading } = useQuery('admin', async () => {
+    const res = await API.GET('/admin');
+    return res.data;
+  });
 
   if (isLoading) {
     return <SkeletonBoardContainer width="360px" height="240px" />;

--- a/src/components/display/dashboard/home/board/History.jsx
+++ b/src/components/display/dashboard/home/board/History.jsx
@@ -15,14 +15,10 @@ import { refineHistories } from '@/utils/refineHistory';
 export const History = () => {
   const navigate = useNavigate();
 
-  const { data, isLoading } = useQuery(
-    'history',
-    async () => {
-      const res = await API.GET('/histories');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data, isLoading } = useQuery('history', async () => {
+    const res = await API.GET('/histories');
+    return res.data;
+  });
 
   if (isLoading) {
     return <SkeletonBoardContainer width="360px" height="240px" />;

--- a/src/components/display/dashboard/home/board/User.jsx
+++ b/src/components/display/dashboard/home/board/User.jsx
@@ -12,14 +12,10 @@ import { API } from '@/utils/api';
 
 export const User = () => {
   const navigate = useNavigate();
-  const { data, isLoading } = useQuery(
-    'user',
-    async () => {
-      const res = await API.GET('/users');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data, isLoading } = useQuery('user', async () => {
+    const res = await API.GET('/users');
+    return res.data;
+  });
 
   if (isLoading) {
     return <SkeletonBoardContainer width="360px" height="240px" />;

--- a/src/components/layouts/MainLayout.jsx
+++ b/src/components/layouts/MainLayout.jsx
@@ -7,6 +7,8 @@ export const Main = styled.main`
   width: 100%;
   height: 100%;
   margin: 0px auto;
+
+  overflow-x: hidden;
 `;
 
 export const MainLayout = () => {

--- a/src/components/navigation/DashboardNav.jsx
+++ b/src/components/navigation/DashboardNav.jsx
@@ -37,7 +37,7 @@ const Logo = styled.div.attrs({
     height 0.4s ${cubicBezier};
   width: 82px;
   height: 82px;
-  background-image: var(--sqaure-logo-url);
+  background-image: var(--square-logo-url);
   background-size: contain;
   background-repeat: no-repeat;
 

--- a/src/components/navigation/Navigation.jsx
+++ b/src/components/navigation/Navigation.jsx
@@ -96,9 +96,10 @@ const MobileMenuDisplay = styled.div`
 const NavMenus = styled.div`
   position: fixed;
   top: 0;
-  left: 0;
+  left: 50%;
+  transform: translateX(-50%);
 
-  width: 100vw;
+  width: fit-content;
   height: 80px;
 
   display: flex;
@@ -111,6 +112,7 @@ const NavMenus = styled.div`
     position: static;
     flex-direction: column;
     gap: 30px;
+    transform: translateX(0%);
   }
 `;
 
@@ -136,7 +138,7 @@ export const Navigation = () => {
       <MenuWrapper $active={menu_spread_active}>
         <NavMenus>
           <Link
-            to="/"
+            to="/#history"
             style={menu_style}
             onClick={() => {
               setMenuSpreadActive(false);
@@ -146,7 +148,7 @@ export const Navigation = () => {
             연혁
           </Link>
           <Link
-            to="/"
+            to="/#executives"
             style={menu_style}
             onClick={() => {
               setMenuSpreadActive(false);
@@ -156,7 +158,7 @@ export const Navigation = () => {
             임원진
           </Link>
           <Link
-            to="/"
+            to="/#education"
             style={menu_style}
             onClick={() => {
               setMenuSpreadActive(false);
@@ -165,7 +167,13 @@ export const Navigation = () => {
           >
             활동
           </Link>
-          <Link to="/board" style={menu_style}>
+          <Link
+            to="/board"
+            style={menu_style}
+            onClick={() => {
+              setMenuSpreadActive(false);
+            }}
+          >
             소식지
           </Link>
         </NavMenus>
@@ -176,10 +184,22 @@ export const Navigation = () => {
             </>
           ) : (
             <>
-              <Link to="/login" style={menu_style}>
+              <Link
+                to="/login"
+                style={menu_style}
+                onClick={() => {
+                  setMenuSpreadActive(false);
+                }}
+              >
                 로그인
               </Link>
-              <Link to="/signup" style={menu_style}>
+              <Link
+                to="/signup"
+                style={menu_style}
+                onClick={() => {
+                  setMenuSpreadActive(false);
+                }}
+              >
                 회원가입
               </Link>
             </>

--- a/src/components/navigation/footer/Footer.jsx
+++ b/src/components/navigation/footer/Footer.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import VerticalLogoSVG from '@/assets/kert_logos/Vertical.svg';
 import { SNSButton } from './SNSButton';
-import { ThemeSwitcher } from '../ThemeSwitcher';
+import { ThemeSwitcher } from './ThemeSwitcher';
 
 const FooterWrapper = styled.footer`
   width: 100%;

--- a/src/components/navigation/footer/ThemeSwitcher.jsx
+++ b/src/components/navigation/footer/ThemeSwitcher.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import useTheme from '@/hooks/theme/useTheme';
-import { Toggle } from '../forms/Toggle';
+import { Toggle } from '@components/forms/Toggle';
 
 import MoonSVG from '@/assets/icons/themeswitcher/moon.svg';
 import SunSVG from '@/assets/icons/themeswitcher/sun.svg';
@@ -22,9 +22,9 @@ export const ThemeSwitcher = () => {
 
   return (
     <ThemeSwitcherWrapper>
-      <SunSVG width="30px" height="30px" stroke="gray" />
-      <Toggle checked={theme === 'dark'} onChange={toggleTheme} />
-      <MoonSVG width="26px" height="26px" fill="gray" />
+      <SunSVG width="26px" height="26px" stroke="gray" />
+      <Toggle size="m" checked={theme === 'dark'} onChange={toggleTheme} />
+      <MoonSVG width="23px" height="23px" fill="gray" />
     </ThemeSwitcherWrapper>
   );
 };

--- a/src/hooks/histories/query.js
+++ b/src/hooks/histories/query.js
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query';
 import { API } from '@/utils/api';
-import { refineHistories } from '../../utils/refineHistory';
+import { refineHistories } from '@/utils/refineHistory';
+import SAMPLE_HISTORIES from '@/utils/sampleHistories';
 
 export function useHistoriesQuery() {
   return useQuery({
@@ -11,7 +12,7 @@ export function useHistoriesQuery() {
         return refineHistories(res.data);
       } catch {
         // console.warn(`History API 요청에 실패했습니다.`);
-        return {};
+        return refineHistories(SAMPLE_HISTORIES);
       }
     },
   });

--- a/src/hooks/theme/useTheme.js
+++ b/src/hooks/theme/useTheme.js
@@ -21,11 +21,11 @@ const useTheme = () => {
     const darkThemeLink = document.getElementById('dark-theme');
 
     if (theme === 'dark') {
-      darkThemeLink.disabled = false;
-      lightThemeLink.disabled = true;
+      if (darkThemeLink) darkThemeLink.disabled = false;
+      if (lightThemeLink) lightThemeLink.disabled = true;
     } else {
-      darkThemeLink.disabled = true;
-      lightThemeLink.disabled = false;
+      if (darkThemeLink) darkThemeLink.disabled = true;
+      if (lightThemeLink) lightThemeLink.disabled = false;
     }
   };
 

--- a/src/pages/Board.jsx
+++ b/src/pages/Board.jsx
@@ -150,14 +150,10 @@ export default function Board() {
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebounce(search, 500);
 
-  const { data: adminData } = useQuery(
-    'admin',
-    async () => {
-      const res = await API.GET('/admin');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data: adminData } = useQuery('admin', async () => {
+    const res = await API.GET('/admin');
+    return res.data;
+  });
 
   const { data, isLoading } = useQuery(
     ['posts-tag-search', tag, debouncedSearch],

--- a/src/pages/History.jsx
+++ b/src/pages/History.jsx
@@ -19,6 +19,11 @@ const Wrapper = styled.div`
 const TitleWrapper = styled.div`
   margin-top: 200px;
   margin-bottom: 150px;
+
+  @media (max-width: 768px) {
+    margin-top: 130px;
+    margin-bottom: 100px;
+  }
 `;
 
 const Title = styled(Span).attrs({
@@ -26,19 +31,28 @@ const Title = styled(Span).attrs({
 })`
   display: block;
   text-align: center;
-  font-size: clamp(36px, 5vw, 52px);
+  font-size: 45px;
   word-break: keep-all;
+
+  @media (max-width: 768px) {
+    font-size: 28px;
+  }
 `;
 
 const Description = styled(Span).attrs({
   $weight: 'light',
-  $color: 'rgba(255, 255, 255, 0.7)',
+  $color: '--secondary-text-color',
 })`
   display: block;
   text-align: center;
-  font-size: clamp(16px, 2.5vw, 24px);
+  font-size: 24px;
   word-break: keep-all;
-  margin-top: 10px;
+  margin-top: 20px;
+
+  @media (max-width: 768px) {
+    margin-top: 16px;
+    font-size: 16px;
+  }
 `;
 
 const HistoriesWrapper = styled.div`
@@ -51,9 +65,14 @@ const Year = styled(Span).attrs({
 })`
   width: 100px;
   text-align: left;
-  font-size: clamp(36px, 4vw, 40px);
+  font-size: 32px;
   word-break: keep-all;
-  color: ${(props) => props.$color || '#FFFFFF'};
+  color: var(--primary-text-color);
+
+  @media (max-width: 768px) {
+    width: fit-content;
+    font-size: 24px;
+  }
 `;
 
 const YearHistoryContainer = styled.div`
@@ -67,6 +86,13 @@ const YearHistoryContainer = styled.div`
   transition:
     opacity 0.6s ease-in-out 0.1s,
     transform 0.6s ease-out 0.1s;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 100px;
+  }
 `;
 
 const HistoryCardContainer = styled.div`
@@ -77,6 +103,10 @@ const HistoryCardContainer = styled.div`
   align-content: flex-start;
   padding: 0px;
   gap: 20px;
+
+  @media (max-width: 768px) {
+    align-items: center;
+  }
 `;
 
 const HistoryCard = styled.div`
@@ -105,18 +135,26 @@ const Month = styled(Span).attrs((props) => ({
   $weight: 'bold',
   $color: props.$color || '#FFFFFF',
 }))`
-  font-size: clamp(18px, 2vw, 12px);
+  font-size: 16px;
   word-break: keep-all;
-  color: ${(props) => props.$color};
+  color: var(--primary-text-color);
+
+  @media (max-width: 768px) {
+    font-size: 13px;
+  }
 `;
 
 const HistoryContent = styled(Span).attrs((props) => ({
   $weight: 'regular',
   $color: props.$color || '#FFFFFF',
 }))`
-  font-size: clamp(14px, 2vw, 12px);
+  font-size: 16px;
   word-break: keep-all;
-  color: ${(props) => props.$color};
+  color: var(--secondary-text-color);
+
+  @media (max-width: 768px) {
+    font-size: 13px;
+  }
 `;
 
 export default function History() {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,97 +4,108 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 
 import { useAuth } from '@components/navigation/AuthContext';
+import { Text } from '@components/typograph/Text';
+import { Button } from '@components/forms/Button';
 
 import { API } from '@/utils/api';
 
-import '@/styles/font.css';
-
 const Container = styled.div`
-  background-color: #080f17;
+  width: 100vw;
+  height: 100vh;
+
   margin: 0;
-  padding: 0;
+  box-sizing: border-box;
+
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  height: 100vh;
-  width: 100vw;
-`;
 
-const LoginContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  position: relative;
+  background-color: var(--body-background);
 `;
 
 const LoginBox = styled.div`
-  background-color: #1b1e27;
+  width: 500px;
+
   padding: 50px;
-  border-radius: 10px;
-  width: 450px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  gap: 57px;
+
+  border-radius: 30px;
+
+  background-color: var(--container-primary-background);
+  border: 1px solid var(--container-border);
+
+  @media (max-width: 768px) {
+    margin: 100px 0;
+    padding: 30px;
+    border: none;
+  }
 `;
 
 const LoginHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  position: relative;
-  padding-bottom: 20px;
+  align-items: center;
+`;
 
-  h1 {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 300;
-    color: #ffffff;
-  }
-
-  h2 {
-    margin: 10px 0 20px 0;
-    font-size: 28px;
-    font-weight: 700;
-    color: #ffffff;
-  }
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 `;
 
 const KertLogo = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
+  width: 103px;
+  height: 101px;
 
-  img {
-    width: 80px;
-    height: 80px;
-    border-radius: 50%;
+  background-image: var(--square-logo-url);
+  background-size: cover;
+
+  opacity: 0.1;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  & > button {
+    margin-top: 20px;
   }
 `;
 
-const InputGroup = styled.div`
-  margin-right: 25px;
-  margin-bottom: 20px;
-
-  label {
-    display: block;
-    margin-bottom: 5px;
-    font-size: 18px;
-    color: #ffffff;
+const InputWrapper = styled.div`
+  & > span {
+    margin-left: 10px;
+    margin-bottom: 8px;
   }
+`;
 
-  input {
-    width: 100%;
-    padding: 15px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    background-color: #1c1f25;
-    color: white;
-    outline: none;
-  }
+const Input = styled.input`
+  transition:
+    border-color 0.2s ease-out,
+    background-color 0.2s ease-out;
 
-  input:focus {
+  width: 100%;
+  height: 56px;
+
+  padding: 20px;
+  box-sizing: border-box;
+  border-radius: 14px;
+
+  background-color: var(--container-primary-background);
+  border: 1px solid var(--container-border);
+  color: var(--primary-text-color);
+  outline: none;
+
+  &:focus {
     border: 1px solid #4a90e2; /* 파란색 테두리 */
     box-shadow: none; /* 흰색 테두리 제거 */
+    background-color: var(--container-secondary-background);
   }
 `;
 
@@ -104,24 +115,11 @@ const ErrorMessage = styled.p`
   margin-top: 10px;
 `;
 
-const LoginButton = styled.button`
-  width: 100%;
-  padding: 15px;
-  background-color: #4a90e2;
-  border: none;
-  border-radius: 5px;
-  color: white;
-  font-size: 20px;
-  cursor: pointer;
-  margin-top: 20px;
-  margin-right: 25px;
-`;
-
 const SignupLink = styled.div`
   margin-top: 20px;
   text-align: center;
   font-size: 14px;
-  color: #ccc;
+  color: var(--secondary-text-color);
 `;
 
 export default function Login() {
@@ -186,75 +184,78 @@ export default function Login() {
 
   return (
     <Container>
-      <LoginContainer>
-        <LoginBox>
-          <LoginHeader>
-            <div className="header-text">
-              <h1>Login to KERT</h1>
-              <h2>로그인</h2>
-            </div>
-            <KertLogo>
-              <img src="../logo/white_square.png" alt="kert-logo" />
-            </KertLogo>
-          </LoginHeader>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <InputGroup>
-              <label>학번</label>
-              <input
-                type="text"
-                placeholder="학번"
-                {...register('student', {
-                  required: '학번을 입력해주세요.',
-                  minLength: {
-                    value: 10,
-                    message: '학번은 10자리 숫자여야 합니다.',
-                  },
-                  pattern: {
-                    value: /^[0-9]{10}$/,
-                    message: '학번은 10자리 숫자여야 합니다.',
-                  },
-                })}
-              />
-              {errors.student && (
-                <ErrorMessage>{errors.student.message}</ErrorMessage>
-              )}
-            </InputGroup>
+      <LoginBox>
+        <LoginHeader>
+          <TitleWrapper>
+            <Text size="m" weight="light" color="--secondary-text-color">
+              Login to KERT
+            </Text>
+            <Text size="sxl" weight="bold">
+              로그인
+            </Text>
+          </TitleWrapper>
+          <KertLogo />
+        </LoginHeader>
+        <Form onSubmit={handleSubmit(onSubmit)}>
+          <InputWrapper>
+            <Text size="s" weight="regular">
+              학번
+            </Text>
+            <Input
+              type="text"
+              placeholder="2024000000"
+              {...register('student', {
+                required: '학번을 입력해주세요.',
+                minLength: {
+                  value: 10,
+                  message: '학번은 10자리 숫자여야 합니다.',
+                },
+                pattern: {
+                  value: /^[0-9]{10}$/,
+                  message: '학번은 10자리 숫자여야 합니다.',
+                },
+              })}
+            />
+            {errors.student && (
+              <ErrorMessage>{errors.student.message}</ErrorMessage>
+            )}
+          </InputWrapper>
+          <InputWrapper>
+            <Text size="s" weight="regular">
+              비밀번호
+            </Text>
+            <Input
+              type="password"
+              placeholder="비밀번호"
+              {...register('password', {
+                required: '비밀번호를 입력해주세요',
+                minLength: {
+                  value: 8,
+                  message: '비밀번호는 8자리 이상이여야 합니다. ',
+                },
+                pattern: {
+                  value:
+                    /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,20}$/,
+                  message:
+                    '비밀번호는 숫자, 영문 대문자·소문자, 특수문자를 포함해야 합니다.',
+                },
+              })}
+            />
+            {errors.password && (
+              <ErrorMessage>{errors.password.message}</ErrorMessage>
+            )}
+          </InputWrapper>
 
-            <InputGroup>
-              <label>비밀번호</label>
-              <input
-                type="password"
-                placeholder="비밀번호"
-                {...register('password', {
-                  required: '비밀번호를 입력해주세요',
-                  minLength: {
-                    value: 8,
-                    message: '비밀번호는 8자리 이상이여야 합니다. ',
-                  },
-                  pattern: {
-                    value:
-                      /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,20}$/,
-                    message:
-                      '비밀번호는 숫자, 영문 대문자·소문자, 특수문자를 포함해야 합니다.',
-                  },
-                })}
-              />
-              {errors.password && (
-                <ErrorMessage>{errors.password.message}</ErrorMessage>
-              )}
-            </InputGroup>
-
-            {/* 에러 메시지 표시 */}
-            {error && <ErrorMessage>{error}</ErrorMessage>}
-
-            <LoginButton>로그인</LoginButton>
-          </form>
-
+          {/* 에러 메시지 표시 */}
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+          <Button width="100%" height="60px">
+            로그인
+          </Button>
           <SignupLink>
             계정이 없으신가요?<Link to="/signup"> 회원가입</Link>
           </SignupLink>
-        </LoginBox>
-      </LoginContainer>
+        </Form>
+      </LoginBox>
     </Container>
   );
 }

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -3,7 +3,7 @@ import { Footer } from '@components/navigation/footer/Footer';
 
 export default function MainPage() {
   return (
-    <div style={{ overflowX: 'hidden' }}>
+    <>
       <Section.Section1 />
       <Section.Section2 />
       <Section.Section3 />
@@ -11,6 +11,6 @@ export default function MainPage() {
       <Section.Section5 />
       <Section.Section6 />
       <Footer />
-    </div>
+    </>
   );
 }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -5,117 +5,128 @@ import styled from 'styled-components';
 import useAlert from '@/hooks/modal/useAlert';
 
 import { Text } from '@components/typograph/Text';
+import { Button } from '@components/forms/Button';
 import { Alert } from '@components/forms/modal/Alert';
 
 import { API } from '@/utils/api';
-import '@/font/main_font.css';
 
 const Container = styled.div`
-  background-color: #080f17;
-  display: flex;
-  justify-content: center;
   width: 100vw;
-  height: 100vh;
-  margin: 0;
-  padding: 0;
-`;
 
-const SignUpContainer = styled.div`
+  margin: 0;
+
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  flex-direction: row;
   justify-content: center;
-  height: 100%;
-  position: relative;
-  top: 120px;
-  padding-top: 60px;
-  padding-bottom: 150px;
+  align-items: center;
+
+  background-color: var(--body-background);
 `;
 
 const SignUpBox = styled.div`
-  background-color: #1b1e27;
+  width: 914px;
+
+  margin: 160px 0;
   padding: 50px;
-  border-radius: 10px;
-  width: 500px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  gap: 57px;
+
+  border-radius: 30px;
+
+  background-color: var(--container-primary-background);
+  border: 1px solid var(--container-border);
+
+  @media (max-width: 768px) {
+    margin: 100px 0;
+    padding: 30px;
+    border: none;
+  }
 `;
 
 const SignUpHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  position: relative;
-  padding-bottom: 20px;
+  align-items: center;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 `;
 
 const KertLogo = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
+  width: 103px;
+  height: 101px;
 
-  img {
-    width: 80px;
-    height: 80px;
-    border-radius: 50%;
-  }
+  background-image: var(--square-logo-url);
+  background-size: cover;
+
+  opacity: 0.1;
 `;
 
 const SignUpForm = styled.form`
-  .input-group {
-    margin-bottom: 25px;
-    margin-right: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+`;
 
-    label {
-      display: block;
-      margin-bottom: 5px;
-      font-size: 18px;
-      color: #ffffff;
-    }
+const InputGroup = styled.div`
+  width: 100%;
 
-    input {
-      width: 100%;
-      padding: 15px;
-      border: 1px solid #ccc;
-      border-radius: 5px;
-      background-color: #1c1f25;
-      color: white;
-      outline: none;
-    }
+  display: flex;
+  gap: 20px;
 
-    input:focus {
-      border-color: #3b82f6;
-      box-shadow: none;
-      background-color: #1c1f25; /* 배경색은 유지 */
-    }
-
-    input::placeholder {
-      font-size: 16px;
-    }
-
-    .error-message {
-      color: #ff4d4d;
-      font-size: 14px;
-      margin-top: 10px;
-    }
+  & > * {
+    width: 100%;
   }
 `;
 
-const SignUpButton = styled.button`
+const InputWrapper = styled.div`
+  & > span {
+    margin-left: 10px;
+    margin-bottom: 8px;
+  }
+
+  .error-message {
+    margin-left: 10px;
+    color: var(--danger-color);
+    font-size: 14px;
+    margin-top: 10px;
+  }
+`;
+
+const Input = styled.input`
+  transition:
+    border-color 0.2s ease-out,
+    background-color 0.2s ease-out;
+
   width: 100%;
-  padding: 15px;
-  background-color: #4a90e2;
-  border: none;
-  border-radius: 5px;
-  color: white;
-  font-size: 20px;
-  cursor: pointer;
-  margin-top: 20px;
+  height: 56px;
+
+  padding: 20px;
+  box-sizing: border-box;
+  border-radius: 14px;
+
+  background-color: var(--container-primary-background);
+  border: 1px solid var(--container-border);
+  color: var(--primary-text-color);
+  outline: none;
+
+  &:focus {
+    border: 1px solid #4a90e2; /* 파란색 테두리 */
+    box-shadow: none; /* 흰색 테두리 제거 */
+    background-color: var(--container-secondary-background);
+  }
 `;
 
 const LoginLink = styled.div`
-  margin-top: 20px;
   text-align: center;
   font-size: 14px;
-  color: #ccc;
+  color: var(--secondary-text-color);
 `;
 
 export default function SignUp() {
@@ -170,62 +181,69 @@ export default function SignUp() {
 
   return (
     <Container>
-      <SignUpContainer>
-        <SignUpBox>
-          <SignUpHeader>
-            <div>
-              <Text size="l" weight="bold" color="#ffffff">
-                Sign Up to KERT
-              </Text>
-              <Text size="sxl" weight="bold" color="#ffffff">
-                회원가입
-              </Text>
-            </div>
-            <KertLogo>
-              <img src="../logo/white_square.png" alt="kert-logo" />
-            </KertLogo>
-          </SignUpHeader>
-          <SignUpForm onSubmit={handleSubmit(onSubmit)}>
-            {/* name */}
-            <div className="input-group">
-              <label>이름</label>
-              <input
-                type="text"
-                placeholder="홍길동"
-                {...register('username', {
-                  required: '이름을 입력해주세요.',
-                  pattern: {
-                    value: /^[가-힣]{2,5}$/,
-                    message: '올바른 이름을 입력해주세요. (한글 2~5자)',
-                  },
-                })}
-              />
-              {errors.username && (
-                <p className="error-message">{errors.username.message}</p>
-              )}
-            </div>
-            {/* student number */}
-            <div className="input-group">
-              <label>학번</label>
-              <input
-                type="text"
-                placeholder="2024000000"
-                {...register('student', {
-                  required: '학번을 입력해주세요.',
-                  pattern: {
-                    value: /^[0-9]{10}$/,
-                    message: '학번은 숫자 10자리로 입력해주세요.',
-                  },
-                })}
-              />
-              {errors.student && (
-                <p className="error-message">{errors.student.message}</p>
-              )}
-            </div>
+      <SignUpBox>
+        <SignUpHeader>
+          <TitleWrapper>
+            <Text size="m" weight="light" color="--secondary-text-color">
+              Sign Up to KERT
+            </Text>
+            <Text size="sxl" weight="bold">
+              회원가입
+            </Text>
+          </TitleWrapper>
+          <KertLogo />
+        </SignUpHeader>
+        <SignUpForm onSubmit={handleSubmit(onSubmit)}>
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}
+          >
+            {/* name & student_id */}
+            <InputGroup>
+              <InputWrapper>
+                <Text size="s" weight="regular">
+                  이름
+                </Text>
+                <Input
+                  type="text"
+                  placeholder="홍길동"
+                  {...register('username', {
+                    required: '이름을 입력해주세요.',
+                    pattern: {
+                      value: /^[가-힣]{2,5}$/,
+                      message: '올바른 이름을 입력해주세요. (한글 2~5자)',
+                    },
+                  })}
+                />
+                {errors.username && (
+                  <p className="error-message">{errors.username.message}</p>
+                )}
+              </InputWrapper>
+              <InputWrapper>
+                <Text size="s" weight="regular">
+                  학번
+                </Text>
+                <Input
+                  type="text"
+                  placeholder="2024000000"
+                  {...register('student', {
+                    required: '학번을 입력해주세요.',
+                    pattern: {
+                      value: /^[0-9]{10}$/,
+                      message: '학번은 숫자 10자리로 입력해주세요.',
+                    },
+                  })}
+                />
+                {errors.student && (
+                  <p className="error-message">{errors.student.message}</p>
+                )}
+              </InputWrapper>
+            </InputGroup>
             {/* e-mail */}
-            <div className="input-group">
-              <label>이메일</label>
-              <input
+            <InputWrapper>
+              <Text size="s" weight="regular">
+                이메일
+              </Text>
+              <Input
                 type="email"
                 placeholder="kert@gmail.com"
                 {...register('mail', {
@@ -239,78 +257,86 @@ export default function SignUp() {
               {errors.mail && (
                 <p className="error-message">{errors.mail.message}</p>
               )}
-            </div>
-            {/* major */}
-            <div className="input-group">
-              <label>전공</label>
-              <input
-                type="text"
-                placeholder="심컴/글솝/플솝"
-                {...register('major', {
-                  required: '전공을 입력해주세요.',
-                  pattern: {
-                    value: /^[가-힣]{2}$/,
-                    message: '올바른 형식으로 입력해주세요. ',
-                  },
-                })}
-              />
-              {errors.major && (
-                <p className="error-message">{errors.major.message}</p>
-              )}
-            </div>
-            {/* generation */}
-            <div className="input-group">
-              <label>기수</label>
-              <input
-                type="text"
-                placeholder="2024-1"
-                {...register('generation', {
-                  required: '기수를 입력해주세요.',
-                  pattern: {
-                    value: /^(20\d{2})-(1|2)$/,
-                    message:
-                      '기수는 "연도-학기" 형식으로 입력해주세요. 예: 2024-1',
-                  },
-                })}
-              />
-              {errors.generation && (
-                <p className="error-message">{errors.generation.message}</p>
-              )}
-            </div>
-            {/* password */}
-            <div className="input-group">
-              <label>비밀번호</label>
-              <input
-                type="password"
-                placeholder="비밀번호"
-                {...register('password', {
-                  required: '비밀번호를 입력해주세요.',
-                  minLength: {
-                    value: 8,
-                    message: '비밀번호는 8자리 이상이여야 합니다. ',
-                  },
-                  pattern: {
-                    value:
-                      /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,20}$/,
-                    message:
-                      '비밀번호는 숫자, 영문 대문자·소문자, 특수문자를 포함해야 합니다.',
-                  },
-                })}
-              />
-              {errors.password && (
-                <p className="error-message">{errors.password.message}</p>
-              )}
-            </div>
-
-            <SignUpButton type="submit">회원가입</SignUpButton>
-            <LoginLink>
-              이미 계정이 있으신가요? <Link to="/login">로그인</Link>
-            </LoginLink>
-          </SignUpForm>
-        </SignUpBox>
-        {/* Alert 컴포넌트 렌더링 */}
-        <Alert isOpen={isOpen} closeAlert={closeAlert} />
-      </SignUpContainer>
+            </InputWrapper>
+            {/* major & generation */}
+            <InputGroup>
+              <InputWrapper>
+                <Text size="s" weight="regular">
+                  전공
+                </Text>
+                <Input
+                  type="text"
+                  placeholder="심컴/글솝/플솝"
+                  {...register('major', {
+                    required: '전공을 입력해주세요.',
+                    pattern: {
+                      value: /^[가-힣]{2}$/,
+                      message: '올바른 형식으로 입력해주세요. ',
+                    },
+                  })}
+                />
+                {errors.major && (
+                  <p className="error-message">{errors.major.message}</p>
+                )}
+              </InputWrapper>
+              <InputWrapper>
+                <Text size="s" weight="regular">
+                  기수
+                </Text>
+                <Input
+                  type="text"
+                  placeholder="2024-1"
+                  {...register('generation', {
+                    required: '기수를 입력해주세요.',
+                    pattern: {
+                      value: /^(20\d{2})-(1|2)$/,
+                      message:
+                        '기수는 "연도-학기" 형식으로 입력해주세요. 예: 2024-1',
+                    },
+                  })}
+                />
+                {errors.generation && (
+                  <p className="error-message">{errors.generation.message}</p>
+                )}
+              </InputWrapper>
+            </InputGroup>
+          </div>
+          {/* password */}
+          <InputWrapper>
+            <Text size="s" weight="regular">
+              비밀번호
+            </Text>
+            <Input
+              type="password"
+              placeholder="비밀번호"
+              {...register('password', {
+                required: '비밀번호를 입력해주세요.',
+                minLength: {
+                  value: 8,
+                  message: '비밀번호는 8자리 이상이여야 합니다. ',
+                },
+                pattern: {
+                  value:
+                    /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,20}$/,
+                  message:
+                    '비밀번호는 숫자, 영문 대문자·소문자, 특수문자를 포함해야 합니다.',
+                },
+              })}
+            />
+            {errors.password && (
+              <p className="error-message">{errors.password.message}</p>
+            )}
+          </InputWrapper>
+          <Button width="100%" height="60px">
+            회원가입
+          </Button>
+          <LoginLink>
+            이미 계정이 있으신가요? <Link to="/login">로그인</Link>
+          </LoginLink>
+        </SignUpForm>
+      </SignUpBox>
+      {/* Alert 컴포넌트 렌더링 */}
+      <Alert isOpen={isOpen} closeAlert={closeAlert} />
     </Container>
   );
 }

--- a/src/pages/dashboard/Admin.jsx
+++ b/src/pages/dashboard/Admin.jsx
@@ -32,14 +32,10 @@ export default function Admin() {
   const { openConfirm, closeConfirm } = useConfirm();
   const { openAlert } = useAlert();
 
-  const { data, isLoading, isError } = useQuery(
-    'admin',
-    async () => {
-      const res = await API.GET('/admin');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data, isLoading, isError } = useQuery('admin', async () => {
+    const res = await API.GET('/admin');
+    return res.data;
+  });
 
   const refs = {
     student_id: useRef(),

--- a/src/pages/dashboard/Users.jsx
+++ b/src/pages/dashboard/Users.jsx
@@ -11,14 +11,10 @@ import { API } from '@/utils/api.js';
 import { useQuery } from 'react-query';
 
 export default function User() {
-  const { data, isLoading, isError } = useQuery(
-    'user',
-    async () => {
-      const res = await API.GET('/users');
-      return res.data;
-    },
-    { retry: 2 },
-  );
+  const { data, isLoading, isError } = useQuery('user', async () => {
+    const res = await API.GET('/users');
+    return res.data;
+  });
 
   return (
     <>

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -1,7 +1,7 @@
 :root {
   /* 이미지 url */
   --vertical-logo-url: url('/logo/white_vertical.png');
-  --sqaure-logo-url: url('/logo/white_square.png');
+  --square-logo-url: url('/logo/white_square.png');
   --text-logo-url: url('/logo/white_text.png');
 
   /* Figma 참고해서 컬러 사용 */

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -29,7 +29,7 @@ export const GlobalStyle = createGlobalStyle`
     }
 
     *::-webkit-scrollbar-thumb {
-        background: #ffffff20; /* 스크롤바 색상 */
+        background-color: var(--secondary-text-color); /* 스크롤바 색상 */
         border-radius: 10px; /* 스크롤바 둥근 테두리 */
     }
 

--- a/src/styles/light.css
+++ b/src/styles/light.css
@@ -1,7 +1,7 @@
 :root {
   /* 이미지 url */
   --vertical-logo-url: url('/logo/black_vertical.png');
-  --sqaure-logo-url: url('/logo/black_square.png');
+  --square-logo-url: url('/logo/black_square.png');
   --text-logo-url: url('/logo/black_text.png');
 
   /* Figma 참고해서 컬러 사용 */

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -11,6 +11,7 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  timeout: 3000, // 3초 타임아웃 설정
 });
 
 // 요청 인터셉터: 모든 요청에 액세스 토큰을 헤더에 포함


### PR DESCRIPTION
### Description
올바른 테마 적용 및 Null 에러 수정 외 7가지 수정사항

### Changes
1. fix: useTheme로 인한 Null 에러 해결 (메인페이지 공백 현상 해결)
2. perf: 리액트 쿼리 사용 시 불필요한 retry 제거
3. chore: dark.css/light.css - square 오타 수정
4. chore: ShapeBackground가 더 잘보이도록 투명도 조절
5. chore: 내비바로 소식지/로그인/회원가입 이동 시 자동으로 닫기게 수정
6. chore: History API 요청 실패 시 샘플 데이터 반환
7. chore: 상세 연혁 페이지 Light 테마 및 모바일 UI 지원
8. chore: /login, /signup - 올바른 테마 적용 및 피그마 디자인과 동일하게 레이아웃 수정 / 모바일 UI 대응
9. chore: 라이트 모드의 스크롤바 가시성 향상
10. chore: 하단 좌우 스크롤바 제거

![image](https://github.com/user-attachments/assets/ff56daaa-4569-4c2a-8985-60b848eb549b)
![image](https://github.com/user-attachments/assets/6dc9809a-eb1b-460f-8cdc-bd073abed02b)
![image](https://github.com/user-attachments/assets/e8ee496e-a309-49e1-b39c-dc3554db6b21)


### 추가
#71 와 동일한 작업(테마 적용)이 겹쳐있으므로 현재 PR로 머지하는 것이 좋을 것 같습니다.